### PR TITLE
Prevent rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ function fetchOrders (next, session) {
     var total = response.body.length
     var done = 0
 
-    async.concat(response.body, (item, next) => {
+    async.concatSeries(response.body, (item, next) => {
       request.get({
         url: util.format('https://www.humblebundle.com/api/v1/order/%s?ajax=true', item.gamekey),
         headers: getRequestHeaders(session),
@@ -197,7 +197,7 @@ function fetchOrders (next, session) {
         }
 
         console.log('Fetched bundle information... (%s/%s)', colors.yellow(++done), colors.yellow(total))
-        next(null, response.body)
+        setTimeout(()=>next(null, response.body), 200);
       })
     }, (error, orders) => {
       if (error) {


### PR DESCRIPTION
Slow down fetch process because i had the following error

```sh
Fetched bundle information... (97/112)
Fetched bundle information... (98/112)
Fetched bundle information... (99/112)
An error occured, exiting.
{ Error: connect ETIMEDOUT 216.58.207.51:443
    at Object.exports._errnoException (util.js:1033:11)
    at exports._exceptionWithHostPort (util.js:1056:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1099:14)
  code: 'ETIMEDOUT',
  errno: 'ETIMEDOUT',
  syscall: 'connect',
  address: '216.58.207.51',
  port: 443 }
```