### PR TITLE
Trim item name before appending extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,7 +338,7 @@ function downloadBook (bundle, name, download, callback) {
       return callback(error)
     }
 
-    var fileName = util.format('%s%s', name, getExtension(normalizeFormat(download.name)))
+    var fileName = util.format('%s%s', name.trim(), getExtension(normalizeFormat(download.name)))
     var filePath = path.resolve(downloadPath, sanitizeFilename(fileName))
 
     checkSignatureMatch(filePath, download, (error, matches) => {


### PR DESCRIPTION
Some of the humble bundles have items with spaces at the end.  Trimming
the string leads to much nicer looking filenames.

---

One bundle I had this with is the Neil Gaiman Rarities book bundle.  (Though I'm also a bit annoyed that they named that one "Humble Books Bundle" rather than "Humble Book Bundle" like the rest of them :p)