### PR TITLE
Adding support to download in order of preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ $ humblebundle-ebook-downloader --help
     -V, --version                              output the version number
     -d, --download-folder <downloader_folder>  Download folder (default: download)
     -l, --download-limit <download_limit>      Parallel download limit (default: 1)
-    -f, --format <format>                      What format to download the ebook in (all, cbz, epub, mobi, pdf, pdf_hd) (default: epub)
+    -f, --format <format>                      What format to download the ebook in (all, any, cbz, epub, mobi, pdf, pdf_hd) (default: epub)
+    -o, --order <format>                       What order to prefer ebooks in (cbz, pdf_hd, pdf, epub, mobi)
     --auth-token <auth-token>                  Optional: If you want to run headless, you can specify your authentication cookie from your browser (_simpleauth_sess)
     -a, --all                                  Download all bundles
     --debug                                    Enable debug logging

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const userAgent = util.format('Humblebundle-Ebook-Downloader/%s', packageInfo.ve
 
 const SUPPORTED_FORMATS = ['epub', 'mobi', 'pdf', 'pdf_hd', 'cbz']
 const ALLOWED_FORMATS = SUPPORTED_FORMATS.concat(['all', 'any']).sort()
+const PREFERRED_FORMATS = ['cbz', 'pdf_hd', 'pdf', 'epub', 'mobi']
 
 commander
   .version(packageInfo.version)
@@ -431,14 +432,32 @@ function downloadBundles (next, bundles) {
         return commander.format === 'all' || commander.format === 'any' || normalizedFormat === commander.format
       })
 
+      var bestIndex = 10
       for (var filteredDownload of filteredDownloadStructs) {
-        // This is where we pick the version we want
-        console.log(colors.blue('filteredDownload (%s) || subproduct (%s)'), filteredDownload, subproduct.human_name)
-        bundleDownloads.push({
-          bundle: bundleName,
-          download: filteredDownload,
-          name: subproduct.human_name
-        })
+        // This is where we pick the format we want
+        var index
+        var tempBundles = []
+        console.log(colors.yellow('filteredDownload (%s) || subproduct (%s) || subproduct name (%s)'), filteredDownload, subproduct, subproduct.human_name)
+        if (commander.format === 'any') {
+          console.log(colors.yellow('found any'))
+          // Now we check where the format sits on the list of preference
+          var normalizedFormat = normalizeFormat(filteredDownload.name)
+          index = PREFERRED_FORMATS.indexOf(normalizedFormat)
+          if (index < bestIndex) {
+            if (bestIndex < 10) {
+              bundleDownloads.pop()
+              console.log(colors.green('replacing index'))
+            }
+            bestIndex = index
+            bundleDownloads.push({
+              bundle: bundleName,
+              download: filteredDownload,
+              name: subproduct.human_name
+            })
+            console.log(colors.yellow('tempBundles (%s)', tempBundles))
+          }
+
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -455,16 +455,13 @@ function downloadBundles (next, bundles) {
         // This is where we pick the format we want
         var index
         var tempBundles = []
-        console.log(colors.yellow('filteredDownload (%s) || subproduct (%s) || subproduct name (%s)'), filteredDownload, subproduct, subproduct.human_name)
         if (commander.format === 'any') {
-          console.log(colors.yellow('found any'))
           // Now we check where the format sits on the list of preference
           var normalizedFormat = normalizeFormat(filteredDownload.name)
           index = ORDERED_FORMATS.indexOf(normalizedFormat)
           if (index < bestIndex) {
             if (bestIndex < 10) {
               bundleDownloads.pop()
-              console.log(colors.green('replacing index'))
             }
             bestIndex = index
             bundleDownloads.push({
@@ -472,7 +469,6 @@ function downloadBundles (next, bundles) {
               download: filteredDownload,
               name: subproduct.human_name
             })
-            console.log(colors.yellow('tempBundles (%s)', tempBundles))
           }
 
         }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const os = require('os')
 const userAgent = util.format('Humblebundle-Ebook-Downloader/%s', packageInfo.version)
 
 const SUPPORTED_FORMATS = ['epub', 'mobi', 'pdf', 'pdf_hd', 'cbz']
-const ALLOWED_FORMATS = SUPPORTED_FORMATS.concat(['all']).sort()
+const ALLOWED_FORMATS = SUPPORTED_FORMATS.concat(['all', 'any']).sort()
 
 commander
   .version(packageInfo.version)
@@ -428,10 +428,12 @@ function downloadBundles (next, bundles) {
           bundleFormats.push(normalizedFormat)
         }
 
-        return commander.format === 'all' || normalizedFormat === commander.format
+        return commander.format === 'all' || commander.format === 'any' || normalizedFormat === commander.format
       })
 
       for (var filteredDownload of filteredDownloadStructs) {
+        // This is where we pick the version we want
+        console.log(colors.blue('filteredDownload (%s) || subproduct (%s)'), filteredDownload, subproduct.human_name)
         bundleDownloads.push({
           bundle: bundleName,
           download: filteredDownload,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "humblebundle-ebook-downloader",
+<<<<<<< HEAD
   "version": "1.0.19",
+=======
+  "version": "1.0.18",
+>>>>>>> 72e3cc3 (1.0.18)
   "license": "Unlicense",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "humblebundle-ebook-downloader",
-<<<<<<< HEAD
   "version": "1.0.19",
-=======
-  "version": "1.0.18",
->>>>>>> 72e3cc3 (1.0.18)
   "license": "Unlicense",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humblebundle-ebook-downloader",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "license": "Unlicense",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Many humble bundle ebook bundles don't have the same formats for every item. As it stands, you have to select a format and miss out on books in the bundle or select all and get some books in many formats.

I added a format 'any' that will download one format of each book in order of a preset format preference.

Additionally, I have added a new command line parameter to take in an ordered list of formats. This will download one format of each book in order of the user format preference.